### PR TITLE
Preparing to run tests with ZFS

### DIFF
--- a/.github/workflows/zpools.yaml
+++ b/.github/workflows/zpools.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - actions-test
 
 jobs:
   zpools:

--- a/.github/workflows/zpools.yaml
+++ b/.github/workflows/zpools.yaml
@@ -1,0 +1,25 @@
+name: Zpool testing
+on:
+  push:
+    branches:
+      - main
+      - actions-test
+
+jobs:
+  zpools:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: /tmp
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          sudo apt update
+          sudo apt install -y zfsutils-linux
+      - run: /sbin/modprobe zfs
+      - name: Create sparse image files
+        run: |
+          for i in {01..20}; do truncate -s 9300G $i.raw; done
+
+      # Steps for the actual ansible tests


### PR DESCRIPTION
This PR adds support for running Ansible tests with Github Actions. This doesn't work locally (using github.com/nektos/act) because those just run in a Docker container. GA, however, uses a full VM which means I can install ZFS and create zpools.